### PR TITLE
Fix the byteorder dep to v1.4.1 and release v1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64-compat"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Steven Roose <steven@stevenroose.org>"]
 description = "encodes and decodes base64 as bytes or utf8 - compatible with older Rust versions"
 repository = "https://github.com/stevenroose/rust-base64-compat"
@@ -17,7 +17,7 @@ name = "benchmarks"
 harness = false
 
 [dependencies]
-byteorder = "1.2.6"
+byteorder = "=1.4.1"
 
 [dev-dependencies]
 criterion = "0.2"


### PR DESCRIPTION
byteorder v1.4.2 breaks our MSRV